### PR TITLE
lib/client: adding walkOptions to client options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,17 @@ define(['promise', './xhr', './resource'], function(Promise, xhr, Resource) {
     }).join('#');
   }
 
+  function extend(obj) {
+    var i, prop, source;
+    for (i = 1; i < arguments.length; ++i) {
+      source = arguments[i];
+      for (prop in source) {
+        obj[prop] = source[prop];
+      }
+    }
+    return obj;
+  }
+
   function Client(apiRoot, options) {
     if (typeof apiRoot === 'undefined') {
       throw new Error('Client must be initialized with an API Root');
@@ -78,7 +89,7 @@ define(['promise', './xhr', './resource'], function(Promise, xhr, Resource) {
       type: 'json'
     };
 
-    this._descriptorCache[uri] = xhr(options)
+    this._descriptorCache[uri] = xhr(extend({}, this._options.walkOptions, options))
     .then(function(descriptor) {
       return new Resource(descriptor, this._options.requestOptions);
     }.bind(this))

--- a/test/specs/client.js
+++ b/test/specs/client.js
@@ -58,6 +58,18 @@ define(['chai-as-promised', 'lib/client', 'lib/resource'], function(chaiAsPromis
             return expect(client.walk()).to.become(new Resource(links));
           });
 
+          it('passes walk options to the walk request', function() {
+            var options = { walkOptions: { headers: { foo: 'hello' } } };
+            var client = new Client('/v1/foo', options);
+
+            server.respondWith('OPTIONS', '/v1/foo', function(req) {
+              expect(req.requestHeaders.foo).to.eql('hello');
+              req.respond.apply(req, response);
+            });
+
+            return client.walk();
+          });
+
           it('passes request options to created resources', function() {
             var options = { requestOptions: { headers: { foo: 'hello' } } };
             var client = new Client('/v1/foo', options);


### PR DESCRIPTION
walkOptions will be the request options specficially for the OPTIONS
requests made during the hypermedia walking stage.

Made specifically so as to be able to include authorization headers.